### PR TITLE
fix: no-op when no baseline exists yet for a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7
+
+- When no baseline file exists yet for a test (and `baseline.record` isn't `true`), the extension now behaves as a
+  no-op instead of failing with a generic `BaselineException` — the real failure surfaces normally, as if
+  `BaselineExtension` weren't applied at all.
+
 ## 1.6
 
 - Remove unused kotest dependency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A JUnit 5 extension (published via JitPack as `com.github.beigirad:junit-baseline-extension`) that snapshot-tests
+test *failures*. Instead of asserting expected error messages inline, a test's thrown exception is recorded into a
+JSON baseline file; subsequent runs compare the actual failure against that baseline and fail only if it drifts.
+
+## Commands
+
+```bash
+./gradlew build                 # compile + test
+./gradlew test                  # run tests (asserts against sample-baseline/*.json)
+./gradlew test -Dbaseline.record=true   # re-record sample-baseline/*.json instead of asserting
+./gradlew test --tests "ir.beigirad.junitbaselineextension.BaselineTest"
+./gradlew test --tests "ir.beigirad.junitbaselineextension.BaselineTest.write should create baseline file with recorded failures"
+```
+
+There is no separate lint task configured.
+
+## Architecture
+
+Two source files implement the whole extension:
+
+- `BaselineExtension.kt` — the JUnit 5 `Extension` (`TestExecutionExceptionHandler` +
+  `Before/AfterAll`/`Before/AfterEach`). It wires JUnit lifecycle callbacks to a `Baseline` instance and decides the
+  *identifier* each baseline file is keyed on.
+- `Baseline.kt` — pure logic for recording failures, sanitizing messages, reading/writing the JSON file (via Moshi),
+  and comparing actual vs. expected. Also defines `BaselineException`, whose `getStackTrace()` is overridden to
+  return empty so the *baseline's* own stacktrace doesn't pollute test output — only the wrapped failures' traces are
+  printed (via `message`).
+
+Key behavior to preserve when touching this code:
+
+- **Class-level vs. method-level application** matters a lot. `@ExtendWith(BaselineExtension::class)` on a class
+  means *one* baseline file for the whole class (keyed by simple class name), aggregating every test method's
+  failure. The same annotation on an individual `@Test` method means a baseline file per method, keyed by
+  `ClassName-shortenedMethodName`. `BaselineExtension.isAppliedByClass()` / `isNestedTestClass()` are how the
+  extension tells these cases apart in the `before*`/`after*` callbacks — don't assume `afterEach`/`afterAll` both
+  fire the same logic.
+- `shortenMethodName` derives the method-level filename: first 4 words of the (backtick) display name, lowercased,
+  alphanumeric-only, joined by `.`, plus `.` plus `name.hashCode()`. This is why sample baseline filenames look like
+  `baseline-SampleMethodLevelTest-first.test.-218984446.json`. Changing this format is a breaking change for anyone
+  with existing baseline files.
+- `handleTestExecutionException` **swallows** the throwable (records it, does not rethrow) — that's what lets a
+  "failing" test pass when its failure matches the baseline. The real pass/fail decision happens later in
+  `Baseline.compare`, which throws `BaselineException` on mismatch. Exception: when no baseline file exists yet for
+  that identifier and `baseline.record` isn't `true`, the extension is a no-op — `handleTestExecutionException`
+  rethrows instead of swallowing, and `afterEach`/`afterAll` skip `assertOrWrite` — so a first run without recording
+  behaves as if `BaselineExtension` weren't applied at all (real failures surface normally) rather than failing with
+  a generic `BaselineException` about an empty baseline. `BaselineExtension` tracks this via `hasBaseline`
+  (`Baseline.exists(identifier)`, computed once in `initialize`).
+- Configuration (`baseline.output`, `baseline.root`, `baseline.record`) is read via
+  `ExtensionContext.getConfigurationParameter`, falling back to `System.getProperty` — both JUnit platform config
+  and `-D` system properties must keep working.
+- `baseline.root` sanitization strips absolute paths from exception messages so baseline files are portable across
+  machines/CI. `baseline.record=true` writes/updates baseline files; otherwise the extension asserts against them.
+
+## Sample/test fixtures
+
+`SampleClassLevelTest.kt` and `SampleMethodLevelTest.kt` are fixture test classes (intentionally throwing) used only
+by `BaselineExtensionTest`, which runs them programmatically via `EngineTestKit` (JUnit Platform Testkit) and checks
+the resulting events/files rather than letting them run as part of the normal suite directly. `sample-baseline/*.json`
+are the checked-in expected baseline outputs for those fixtures — if you change `SampleClassLevelTest` /
+`SampleMethodLevelTest` or the filename/format logic, regenerate these with `-Dbaseline.record=true` and diff them
+deliberately (they are assertions, not incidental output).
+
+`BaselineTest.kt` unit-tests `Baseline` directly (no JUnit engine involved) and uses Kotest matchers
+(`shouldBe`, `shouldThrow`, etc.) even though the `kotest-runner-junit5` engine itself isn't used to run these tests —
+it's a `testImplementation` dependency purely for its assertion library.
+
+## Releasing
+
+Version lives in `build.gradle.kts` (`version = "1.7"`). Bump it and add an entry to `CHANGELOG.md` when cutting a
+release; JitPack builds directly from git tags/commits, there's no separate publish step in this repo.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.github.beigirad"
-version = "1.6"
+version = "1.7"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/ir/beigirad/junitbaselineextension/Baseline.kt
+++ b/src/main/kotlin/ir/beigirad/junitbaselineextension/Baseline.kt
@@ -32,6 +32,8 @@ data class Baseline(
         failures[testId] = ExceptionWrapper(throwable)
     }
 
+    fun exists(identifier: String): Boolean = getBaselineFile(identifier).exists()
+
     @TestOnly
     internal fun write(identifier: String) {
         val file = getBaselineFile(identifier)

--- a/src/main/kotlin/ir/beigirad/junitbaselineextension/BaselineExtension.kt
+++ b/src/main/kotlin/ir/beigirad/junitbaselineextension/BaselineExtension.kt
@@ -16,21 +16,32 @@ class BaselineExtension : TestExecutionExceptionHandler,
     BeforeAllCallback,
     BeforeEachCallback {
     private lateinit var baseline: Baseline
+    private lateinit var identifier: String
     private var isRecording: Boolean = false
+    private var hasBaseline: Boolean = false
 
     override fun beforeAll(context: ExtensionContext) {
         if (context.isNestedTestClass()) return
 
-        initialize(context)
+        initialize(
+            context = context,
+            identifier = context.requiredTestClass.simpleName
+        )
     }
 
     override fun beforeEach(context: ExtensionContext) {
         if (context.isAppliedByClass()) return
 
-        initialize(context)
+        initialize(
+            context = context,
+            identifier = context.requiredTestClass.simpleName + "-" + shortenMethodName(context.requiredTestMethod.name)
+        )
     }
 
     override fun handleTestExecutionException(context: ExtensionContext, throwable: Throwable) {
+        // without a baseline to compare against, behave as if the extension weren't applied
+        if (!isRecording && !hasBaseline) throw throwable
+
         // record test failures without throwing, for baseline comparison instead of `throw throwable`
         baseline.recordFailure(context.displayName, throwable)
     }
@@ -38,27 +49,24 @@ class BaselineExtension : TestExecutionExceptionHandler,
     override fun afterEach(context: ExtensionContext) {
         // ignore printing baseline when it applied by class (not by method!)
         if (context.isAppliedByClass()) return
+        if (!isRecording && !hasBaseline) return
 
-        baseline.assertOrWrite(
-            identifier = context.requiredTestClass.simpleName + "-" + shortenMethodName(context.requiredTestMethod.name),
-            recordMode = isRecording
-        )
+        baseline.assertOrWrite(identifier = identifier, recordMode = isRecording)
     }
 
     override fun afterAll(context: ExtensionContext) {
         // avoid writing baselines for nested classes (they are handled in parent)
         if (context.isNestedTestClass()) return
+        if (!isRecording && !hasBaseline) return
 
-        baseline.assertOrWrite(
-            identifier = context.requiredTestClass.simpleName,
-            recordMode = isRecording
-        )
+        baseline.assertOrWrite(identifier = identifier, recordMode = isRecording)
     }
 
-    private fun initialize(context: ExtensionContext) {
+    private fun initialize(context: ExtensionContext, identifier: String) {
         fun getProp(key: String): String? =
             context.getConfigurationParameter(key).orElse(System.getProperty(key))
 
+        this.identifier = identifier
         isRecording = getProp(ARG_RECORD) == "true"
         val baselineRoot = getProp("baseline.root")
         val baselineOutput = getProp("baseline.output") ?: "test-baseline"
@@ -66,6 +74,7 @@ class BaselineExtension : TestExecutionExceptionHandler,
             projectRoot = baselineRoot?.let(::Path),
             baselineOutputParent = Path(baselineOutput)
         )
+        hasBaseline = baseline.exists(identifier)
     }
 
     private fun shortenMethodName(name: String) =

--- a/src/test/kotlin/ir/beigirad/junitbaselineextension/BaselineExtensionTest.kt
+++ b/src/test/kotlin/ir/beigirad/junitbaselineextension/BaselineExtensionTest.kt
@@ -93,7 +93,7 @@ class BaselineExtensionTest {
     }
 
     @Test
-    fun `should propagate real exceptions and skip comparison when no baseline exists for class-level extension`() {
+    fun `should not swallow failures when no baseline exists for class-level extension`() {
         val events = EngineTestKit.engine("junit-jupiter")
             .selectors(DiscoverySelectors.selectClass(SampleClassLevelTest::class.java))
             .configurationParameter("baseline.root", rootPath.absolutePathString())
@@ -116,7 +116,7 @@ class BaselineExtensionTest {
     }
 
     @Test
-    fun `should propagate real exceptions and skip comparison when no baseline exists for method-level extension`() {
+    fun `should not swallow failures when no baseline exists for method-level extension`() {
         val events = EngineTestKit.engine("junit-jupiter")
             .selectors(DiscoverySelectors.selectClass(SampleMethodLevelTest::class.java))
             .configurationParameter("baseline.root", rootPath.absolutePathString())

--- a/src/test/kotlin/ir/beigirad/junitbaselineextension/BaselineExtensionTest.kt
+++ b/src/test/kotlin/ir/beigirad/junitbaselineextension/BaselineExtensionTest.kt
@@ -3,8 +3,11 @@ package ir.beigirad.junitbaselineextension
 import io.kotest.assertions.asClue
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.platform.engine.TestExecutionResult
 import org.junit.platform.engine.discovery.DiscoverySelectors
 import org.junit.platform.testkit.engine.EngineTestKit
 import java.nio.file.Path
@@ -87,5 +90,50 @@ class BaselineExtensionTest {
         withClue(events.containerEvents().debug()) {
             events.containerEvents().failed().count() shouldBe 0
         }
+    }
+
+    @Test
+    fun `should propagate real exceptions and skip comparison when no baseline exists for class-level extension`() {
+        val events = EngineTestKit.engine("junit-jupiter")
+            .selectors(DiscoverySelectors.selectClass(SampleClassLevelTest::class.java))
+            .configurationParameter("baseline.root", rootPath.absolutePathString())
+            .configurationParameter("baseline.output", baselinePath.absolutePathString())
+            .execute()
+
+        withClue(events.containerEvents().debug()) {
+            events.containerEvents().failed().count() shouldBe 0
+        }
+
+        val failedTests = events.testEvents().failed().list()
+        failedTests.size shouldBe 2
+        failedTests.forEach { event ->
+            val throwable = event.getRequiredPayload(TestExecutionResult::class.java).throwable.get()
+            throwable.shouldBeInstanceOf<AssertionError>()
+            throwable.message.orEmpty() shouldContain "failure"
+        }
+
+        baselinePath.resolve("baseline-SampleClassLevelTest.json").exists() shouldBe false
+    }
+
+    @Test
+    fun `should propagate real exceptions and skip comparison when no baseline exists for method-level extension`() {
+        val events = EngineTestKit.engine("junit-jupiter")
+            .selectors(DiscoverySelectors.selectClass(SampleMethodLevelTest::class.java))
+            .configurationParameter("baseline.root", rootPath.absolutePathString())
+            .configurationParameter("baseline.output", baselinePath.absolutePathString())
+            .execute()
+
+        withClue(events.containerEvents().debug()) {
+            events.containerEvents().failed().count() shouldBe 0
+        }
+
+        val failedTests = events.testEvents().failed().list()
+        failedTests.size shouldBe 1
+        val throwable = failedTests.single().getRequiredPayload(TestExecutionResult::class.java).throwable.get()
+        throwable.shouldBeInstanceOf<AssertionError>()
+        throwable.message shouldBe "First failure"
+
+        val baselineFileName = "baseline-SampleMethodLevelTest-first.test.-218984446.json"
+        baselinePath.resolve(baselineFileName).exists() shouldBe false
     }
 }

--- a/src/test/kotlin/ir/beigirad/junitbaselineextension/BaselineTest.kt
+++ b/src/test/kotlin/ir/beigirad/junitbaselineextension/BaselineTest.kt
@@ -73,6 +73,22 @@ class BaselineTest {
     }
 
     @Test
+    fun `exists should return false when baseline file does not exist`() {
+        val baseline = Baseline(projectRoot = rootDir, baselineOutputParent = baselineOutput)
+
+        baseline.exists("non-existent") shouldBe false
+    }
+
+    @Test
+    fun `exists should return true after baseline file is written`() {
+        val baseline = Baseline(projectRoot = rootDir, baselineOutputParent = baselineOutput)
+        baseline.recordFailure("test-1", Throwable("Error 1"))
+        baseline.write("test-identifier")
+
+        baseline.exists("test-identifier") shouldBe true
+    }
+
+    @Test
     fun `read should return empty map when baseline file does not exist`() {
         val baseline = Baseline(projectRoot = rootDir, baselineOutputParent = baselineOutput)
 


### PR DESCRIPTION
## Summary                                                                                                                                                               
  When a test fails and no baseline file exists yet for it (and `baseline.record` isn't `true`), the extension now behaves as a no-op — the real exception surfaces        
  normally, as if `BaselineExtension` weren't applied — instead of swallowing it and failing later with a generic `BaselineException` about an empty baseline.             
                                                                                                                                                                           
  ## Motivation                                                                                                                                                            
  Previously, running a test with `BaselineExtension` applied for the first time (before any baseline had been recorded) produced a confusing generic failure instead of   
  the actual test error, forcing an unnecessary record-then-rerun cycle just to see the real failure.                                                                      
                                                                                                                                                                           
  ## Changes                                                                                                                                                               
  - `Baseline.kt`: add `exists(identifier)` to check whether a baseline file is already present.                                                                           
  - `BaselineExtension.kt`: track `hasBaseline` (computed once in `initialize`); when `!isRecording && !hasBaseline`, rethrow the real throwable from                      
  `handleTestExecutionException` and skip `assertOrWrite` in `afterEach`/`afterAll`.                                                                                       
  - Add tests in `BaselineExtensionTest.kt` and `BaselineTest.kt` covering the no-op behavior for both class-level and method-level extension usage.                       
  - Bump version to `1.7` and add a `CHANGELOG.md` entry.                                                                                                                  
                                                                                                                                                                           
  ## Test Plan                                                                                                                                                             
  - [x] `./gradlew test` passes, including new tests asserting real exceptions propagate and no baseline file is written when none existed yet.                            
 